### PR TITLE
Playbook for Android v.1.0

### DIFF
--- a/Android/CI_Description_And_Setup/README.md
+++ b/Android/CI_Description_And_Setup/README.md
@@ -1,0 +1,83 @@
+# Continuous Integration
+
+## What is CI?
+
+Please refer to [this Wikipedia article](https://en.wikipedia.org/wiki/Continuous_integration) and related sources. In general, it's "this thing that automatically builds your code, runs tests and lints for you". Here I'll focus on explaining how to set it up for our Android GitLab projects. 
+
+You should only ever be reading this if:
+
+* You're curious as to how to set it up, OR
+* You're a manager and have to set it up. 
+
+(if you're in both of these categories, you're good too :-)).
+
+## What are we using?
+
+We are using the CI integrated with GitLab. To read about GitLab CI in general, refer to [this page](https://about.gitlab.com/gitlab-ci/). Here we will focus on the setup for android projects. 
+
+## How does CI work and why do I care?
+
+Every CI must run the code you provide within a [virtual machine](https://en.wikipedia.org/wiki/Virtual_machine) or [container](https://en.wikipedia.org/wiki/Operating-system-level_virtualization). What does that mean?
+
+First, let's establish the basics. From the user perspective (your perspective) this is what happens:
+
+1. You push your code to the repo, 
+2. The GitLab CI runner will detect this fact
+3. The Gitlab CI runner will initiate a series of events according to a special file we will be considering later on (called .gitlab-ci.yml).
+
+Pretty cool, huh? Everything happens automatically and it's magic. But... not so fast.
+
+Step 3 is actually much more complex than it sounds. The series of events you are initiating is being run on some server which is shared across many users (who have no clue that they aren't the only user!). This means that there must be some program which controls what is being run, when it is being run and who should get access to which resources (such as CPUs, RAM etc.) Such a program is called a [hypervisor](https://en.wikipedia.org/wiki/Hypervisor) or container manager (the difference depends on whether VMs or containers are used). To be more brief, I'll go on using the VM and hypervisor terminology as everything that follows translates easily to containers.
+
+Hence, a better approximation of what actually happens for step 3 is the following:
+
+1. The hypervisor running on the server launches a virtual machine with given resource constraints (usually based on how much you pay for the ci)
+2. The hypervisor then executes the series of commands you have requested within .gitlab-ci.yml within the virtual machine
+
+Hence, the user has no clue that he or she doesn't own the machine that is being used to execute what he or she requests. Moreover, the user has no clue what operating system is actually being run on that machine since he or she operates on the virtual machine (which does the job of interfacing with the real operating system for you!). 
+
+The bottom line here is that we must specify what virtual machine the hypervisor should launch for us. This is why we care about this whole issue and it also happens to be the reason for which we need Docker. 
+
+## What is Docker?
+
+First, see some of [this wiki page](https://en.wikipedia.org/wiki/Docker_(software)) remembering that for the purpose of this discussion containers and virtual machines are the same (in reality [they are not](http://electronicdesign.com/dev-tools/what-s-difference-between-containers-and-virtual-machines)).
+
+In short, for our purpose Docker is what we will use to describe and create virtual machine images. In other words, it will be the software we use to describe and create images of the virtual machines in which we will be running tests.
+
+## You will need docker...
+
+Please instal docker refering to these instructions for [Ubuntu](https://www.digitalocean.com/community/tutorials/how-to-install-and-use-docker-on-ubuntu-16-04) or [macOS](https://docs.docker.com/docker-for-mac/)).
+
+## Setting up CI
+
+Setting up CI will require the following steps:
+
+1. Modify the `Dockerfile` file
+2. Log in to the repo using `docker login yale.githost.io:4678`
+3. Build the docker image using `docker build -t yale.githost.io:4678/sdmp/yalemobile-android .`
+4. Push the docker image using `docker push yale.githost.io:4678/sdmp/yalemobile-android`
+5. Update the .gitlab-ci.yml file to reflect the behavior of your CI
+
+Steps 2 - 4 are self-explanatory, so I won't spend time on them. Let's talk about Steps 1 and 5.
+
+## Create the image you need...
+
+In general, this is rather involved and [this tutorial](https://docs.docker.com/engine/getstarted/) should help you get the grasp of it.
+
+You may also just use the current dockerfile as a template to modify. Please refer to the dockerfile [here](https://yale.githost.io/SDMP/YaleMobile-Android/blob/master/Dockerfile).
+
+In general, when you write docker files for Android projects you will need to base them on unix systems with installed java. Some base images are widely available (such as opejdk:8-jdk), which will do the job. Then, on top of that you need to install all of the necessary android stuff (SDK, tooling, images...). 
+
+There are few more tricks that you might find handy. 
+
+1. If you want to run the image you have built locally to test something, use `docker run -it yale.githost.io:4678/sdmp/yalemobile-android`. Exiting the interactive run may be done using `CTRL + D` or the `exit` command.
+2. If you want to delete the image from your local machine to free up some space, use:
+    - `docker rm $(docker ps -a -q)` -- this will stop all of docker jobs
+    - `docker images` -- this will list your images
+    - `docker rmi <hashsum>` -- this will delete the image from your local workspace.
+
+## Updating .gitlab-ci.yml
+
+There is a relatively good guide for creating and modifying this file [here](https://about.gitlab.com/2016/11/30/setting-up-gitlab-ci-for-android-projects/). Keep in mind that the tutorial uses the raw `openjdk-8:jdk` docker image so they download a bunch of things you don't need to! Just make sure to use the docker image you have uploaded before (see the top image directive?). Otherwise it is relatively similar. 
+
+After you went through that tutorial, take a look at the [current `.gitlab-ci.yml` file](https://yale.githost.io/SDMP/YaleMobile-Android/blob/master/.gitlab-ci.yml), which is much better commented. That should give you the idea of what instructions it specifies. Modify whatever you need to!

--- a/Android/Computer_Setup/README.md
+++ b/Android/Computer_Setup/README.md
@@ -1,0 +1,5 @@
+# Computer Setup
+
+For all of our projects we will be using the Android Studio IDE. You may get it using [these instructions from Google.](https://developer.android.com/studio/index.html)
+
+Before you start contributing, please make sure that the IDE, the SDK and the emulators work well.

--- a/Android/Contribution_Guide/README.md
+++ b/Android/Contribution_Guide/README.md
@@ -1,0 +1,28 @@
+# Contribution Guide
+
+Based on the [thoughtbot code reviews guide](https://thoughtbot.com/playbook/developing/code-reviews).
+
+Contributing to any of our projects must be done according to the following set of steps:
+
+1. Choose an issue to work on. That issue should already exist within the list of issues available within GitLab repo. If you wish to propose a new issue, go ahead!
+2. Claim the issue by assigning it to yourself. 
+3. Create a new branch and make changes. Remember to commit and push often and meaningfully. Remember to update the issue as you work on it with. Let others know if there have been any problems!
+4. When you have finished working on the issue at hand and you have written tests for the code you wrote:
+    * Push your code to your remote branch
+    * Wait for the build to finish, tests to run and lint to run. Proceed **only** if all of the above pass. That is, make sure that the code builds, tests run correctly and lint passes.
+    * Submit a [pull request](https://help.github.com/articles/about-pull-requests/) (on GitHub) or [Merge Request](https://docs.gitlab.com/ee/gitlab-basics/add-merge-request.html) (on GitLab). Remember to include a *meaningful* description of the changes included!
+ 5. Ask for review on Slack and be responsive to the comments made by others! You should of course review the requests of others. Please use this [review guide](https://github.com/thoughtbot/guides/tree/master/code-review) to give meaningful and concise feedback!
+ 6. When the review ends and everyone is satisfied:
+    * Squash your commits within the branch into a single commit with a good commit message, which summarizes what issue the branch fixes and what are the significant changes within code
+      * Rebase onto master
+      * Once again, make sure that the build, tests and lints pass (conflict resolution might have influenced this).
+      * Let the person with merge permission know that everything is done!
+      * You now can delete the local branch containing the changes (make sure not to delete the remote branch!)
+7. Let the person with merge privileges:
+     * Rebase the branch onto master
+     * Delete the remote branch
+     
+Everything is done and finished!
+
+If you would like to read up on why the review cycle is important, please refer to the bullet list at the end of [this article](https://thoughtbot.com/playbook/developing/code-reviews).
+      

--- a/Android/README.md
+++ b/Android/README.md
@@ -1,0 +1,10 @@
+# Android Apps [v1.0]
+
+## Table of contents
+1. Application Descriptions
+    * [Yale Mobile Android](./Yale_Mobile_Android)
+ 2. [Computer Setup](./Computer_Setup)
+ 3. [Contribution Guide](./Contribution_Guide)
+ 4. [Style Guide And Linting](./Style_Guide_And_Linting)
+ 5. Management Guide
+    * [CI Description and Setup](./CI_Description_And_Setup)

--- a/Android/Style_Guide_And_Linting/README.md
+++ b/Android/Style_Guide_And_Linting/README.md
@@ -1,0 +1,22 @@
+# Style Guide
+
+For all android projects we will be using the Google Java Style Guide. The painful details of this rigor may be found [here](https://google.github.io/styleguide/javaguide.html). Please make sure you are familiar with the basics at the least. 
+
+# Linting
+
+To make sure that all of our code follows the style guide, we will be using a linter. The linter will be run automatically on all commits by the CLI (TODO: write article and link it here), but you may run it locally on your machine as well. 
+
+We are using [checkstyle](http://checkstyle.sourceforge.net/), which is a linting tool for java code. The linked site will give you all the details you may need, but if you're looking for a ready code sample, here it is. Please keep in mind that the following was tested on ubuntu 16.04 and some changes might be necessary for other systems.
+
+```
+# get the style linter
+wget https://sourceforge.net/projects/checkstyle/files/checkstyle/7.4/checkstyle-7.4-all.jar
+# run and pipe to a new file.
+touch lint_results
+# run the linter
+java -jar checkstyle-7.4-all.jar -c /google_checks.xml app/src/* > lint_results
+# check whether errors have occured and print them if so.
+if [[ $(wc -l < lint_results) -ge 3 ]]; then cat lint_results; exit -1; else exit 0; fi
+```
+
+Note that the style guide linked to before is implemented as a set of rules within google_checks.xml. Feel free to check that out in your free time!

--- a/Android/Yale_Mobile_Android/README.md
+++ b/Android/Yale_Mobile_Android/README.md
@@ -1,0 +1,7 @@
+# Yale Mobile Android
+
+The Yale Mobile Android application is the new Yale mobile app for both students and visitors. 
+
+The repository for the project is currently kept private, but feel free to drop by if you have access and checkout our progress!
+
+Link to repo: https://yale.githost.io/SDMP/YaleMobile-Android

--- a/README.md
+++ b/README.md
@@ -8,19 +8,19 @@ We've made this playbook free under the Creative Commons Attribution-NonCommerci
 
 ## Table of Contents
 1. Logistics
-   * Teams
-   * Hours / scheduling
-   * Reports
+    * Teams
+    * Hours / scheduling
+    * Reports
 2. Project Management
-   * Git workflow
-   * Issue lifecycle
-   * Scrum-lite
+    * Git workflow
+    * Issue lifecycle
+    * Scrum-lite
 3. Tooling
-   * Source code management
-   * Issue tracking
-   * Continuous integration
-   * Communication
+    * Source code management
+    * Issue tracking
+    * Continuous integration
+    * Communication
 4. Development practice
-   * Clean code
-   * Automated testing
-   * Test-driven design
+    * Clean code
+    * Automated testing
+    * Test-driven design


### PR DESCRIPTION
I added the first version of Android playbook. For now I have included:

1. Yale Mobile Android app description (v. short)
2. The Computer setup section (v. short)
3. The Contribution Guide (longer and more controversial I suppose)
4. The style and linting (short, shouldn't be too controversial)
5. CI Description and Setup (long, might be controversial).

Please read through them and suggest changes. I haven't linked to the playbook from what you wrote, mainly because I wasn't sure where to put it. Ideas?

PS
I hate writing playbooks and readmes and documentation in general. Cheers!